### PR TITLE
Fix CI comment typo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 # For details, visit https://github.com/BSData/check-datafiles
 name: CI
 on: [ ]
-# on [ push, pull_request ] Removed to disable chekcs due to wham errors
+# on [ push, pull_request ] Removed to disable checks due to wham errors
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- fix a spelling error in `.github/workflows/ci.yml`

## Testing
- `pip install markdown`
- *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685f405d9dfc832db1912120239df0c8