### PR TITLE
Add Death Guard JSON reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 !*.gst
 
 # Don't ignore docs
+!/docs/
+!/docs/**
 !*.md
 
 # Don't ignore github files

--- a/docs/death_guard_reference.md
+++ b/docs/death_guard_reference.md
@@ -1,0 +1,45 @@
+# Death Guard JSON Reference
+
+This document outlines the structure of the JSON file produced from the
+`Chaos - Death Guard.cat` catalogue. A separate conversion script reads the
+catalogue's XML and assembles a reference object that downstream tools can
+consume.
+
+## JSON Sections
+
+### units
+
+Each unit datasheet found in the catalogue is exported. The script locates all
+`selectionEntry` elements representing a unit and collects their profiles,
+keywords and weapons. These are gathered into an array under `units`.
+
+### detachments
+
+Detachments are discovered under the "Detachment Choice" selection group. For
+each child entry the script records the detachment's name and any linked rules.
+The results populate the `detachments` array.
+
+### enhancements
+
+Enhancements are parsed from upgrade entries flagged within the catalogue. The
+script captures the enhancement name, description and restrictions. These appear
+in the `enhancements` section of the JSON.
+
+### stratagems
+
+The catalogue does not provide structured data for stratagems, so the script
+cannot reliably extract them. This section is left empty or must be filled
+manually.
+
+### army_rules
+
+General army-wide rules are extracted from shared rules or info links such as
+"Nurgle's Gift". These are grouped as `army_rules`.
+
+## Limitations
+
+* The script relies on conventions in the catalogue; unusual formatting may lead
+  to missing or misnamed entries.
+* Because stratagems are absent from the data, they are not currently generated
+  automatically.
+* External catalogue links may include additional abilities not captured here.


### PR DESCRIPTION
## Summary
- add documentation for how the extraction script builds a JSON reference for Death Guard
- allow docs/ directory in repo

## Testing
- `markdownlint docs/death_guard_reference.md`


------
https://chatgpt.com/codex/tasks/task_e_6861fdc2f08c832dac8a8b43a6a3f054